### PR TITLE
Added returns after errors have occurred

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
 /URLTester/obj/*
 /URLTester/bin/*
+URLTester/301test.csv
+.vs/URLTester/v15/.suo
+.vs/URLTester/v15/Server/sqlite3/db.lock
+.vs/URLTester/v15/Server/sqlite3/storage.ide
+.vs/URLTester/v15/Server/sqlite3/storage.ide-shm
+.vs/URLTester/v15/Server/sqlite3/storage.ide-wal

--- a/URLTester/Program.cs
+++ b/URLTester/Program.cs
@@ -52,12 +52,16 @@ namespace _URLTester
             {
                 //if errors then display them
                 testManager.OutPutErrorMessages();
+                Console.ReadLine();
+                return;
             }
 
             if (!testManager.TestLinks())
             {
                 //if errors then display them
                 testManager.OutPutErrorMessages();
+                Console.ReadLine();
+                return;
             }
             
             Console.WriteLine("Running.....");

--- a/URLTester/URLTester.csproj.user
+++ b/URLTester/URLTester.csproj.user
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
-    <StartArguments>-d http://example.com -f C:\Users\adamw\source\repos\URLTester\URLTester\301test.csv -o C:\test\output.txt -t</StartArguments>
+    <StartArguments>-d http://example.com -f D:\projects\URLTester\URLTester\301test.csv -o C:\test\output.txt -t</StartArguments>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
After an error was  logged and displayed to the user, the application was not exiting and it continued to execute with bad data. I have added a return after the display of the errors messages to prevent the application from proceeding.